### PR TITLE
Add options to render multiline items

### DIFF
--- a/api.go
+++ b/api.go
@@ -18,14 +18,16 @@ type outputOpts struct {
 	depth         int
 	indent        string
 	spaceEqBinary bool
+	dictOption    DictOption
+	listOption    ListOption
+	callOption    CallOption
+	tupleOption   TupleOption
 }
 
+// copy the options, will panic on nil argument
 func (o *outputOpts) copy() *outputOpts {
-	return &outputOpts{
-		depth:         o.depth,
-		indent:        o.indent,
-		spaceEqBinary: o.spaceEqBinary,
-	}
+	c := *o
+	return &c
 }
 
 func (o *outputOpts) addDepth(n int) *outputOpts {
@@ -38,7 +40,168 @@ var defaultOpts = outputOpts{
 	depth:         defaultDepth,
 	indent:        defaultIndent,
 	spaceEqBinary: defaultSpaceEqBinary,
+	dictOption:    DictOptionSingleLine,
+	listOption:    ListOptionSingleLine,
+	callOption:    CallOptionSingleLine,
+	tupleOption:   TupleOptionSingleLine,
 }
+
+type (
+	renderOption  uint8
+	multiLineType uint8
+	lastCommaType uint8
+)
+
+const (
+	singleLine multiLineType = iota
+	multiLineMultiple
+	multiLine
+)
+
+const (
+	noLastComma lastCommaType = iota
+	alwaysLastComma
+	lastCommaTwoAndMore
+)
+
+func (ro renderOption) commaType() lastCommaType {
+	return lastCommaType(uint8(ro) % 3)
+}
+
+func (ro renderOption) multiLineType() multiLineType {
+	return multiLineType(uint8(ro) / 3)
+}
+
+// CallOption controls how the function calls are rendered. See examples for
+// details on each specific option.
+type CallOption renderOption
+
+const (
+	// CallOptionSingleLine is the default, render as single line.
+	CallOptionSingleLine CallOption = iota
+	// CallOptionSingleLineComma will render call as single line, with comma after last argument.
+	CallOptionSingleLineComma
+	// CallOptionSingleLineCommaTwoAndMore will render call as single line, with comma after last argument, if there are two or more arguments.
+	CallOptionSingleLineCommaTwoAndMore
+
+	// CallOptionMultilineMultiple will render single argument calls as single line,
+	// and two and more arguments as multiline.
+	CallOptionMultilineMultiple
+	// CallOptionMultilineMultipleComma will render single argument calls as single line,
+	// and two and more arguments as multiline, with comma after last argument.
+	CallOptionMultilineMultipleComma
+	// CallOptionMultilineMultipleCommaTwoAndMore will render single argument calls as single line,
+	// and two and more arguments as multiline, with comma after last argument if two or more argument are present.
+	CallOptionMultilineMultipleCommaTwoAndMore
+
+	// CallOptionMultiline will render call as multiline.
+	CallOptionMultiline
+	// CallOptionMultilineComma will render call as multiline, with comma after last argument.
+	CallOptionMultilineComma
+	// CallOptionMultilineCommaTwoAndMore will render call as multiline, with comma after last argument, if there are two or more argument.
+	CallOptionMultilineCommaTwoAndMore
+
+	callOptionMax
+)
+
+// DictOption controls how the dict literals are rendered. See examples for
+// details on each specific option.
+type DictOption renderOption
+
+const (
+	// DictOptionSingleLine is the default, render as single line.
+	DictOptionSingleLine DictOption = iota
+	// DictOptionSingleLineComma will render dict as single line, with comma after last item.
+	DictOptionSingleLineComma
+	// DictOptionSingleLineCommaTwoAndMore will render dict as single line, with comma after last item, if there are two or more items.
+	DictOptionSingleLineCommaTwoAndMore
+
+	// DictOptionMultilineMultiple will render single element dictionaries as single line,
+	// and two and more elements as multiline.
+	DictOptionMultilineMultiple
+	// DictOptionMultilineMultipleComma will render single element dictionaries as single line,
+	// and two and more elements as multiline, with comma after last item.
+	DictOptionMultilineMultipleComma
+	// DictOptionMultilineMultipleCommaTwoAndMore will render single element dictionaries as single line,
+	// and two and more elements as multiline, with comma after last item if two or more elements are present.
+	DictOptionMultilineMultipleCommaTwoAndMore
+
+	// DictOptionMultiline will render dict as multiline.
+	DictOptionMultiline
+	// DictOptionMultilineComma will render dict as multiline, with comma after last item.
+	DictOptionMultilineComma
+	// DictOptionMultilineCommaTwoAndMore will render dict as multiline, with comma after last item, if there are two or more items.
+	DictOptionMultilineCommaTwoAndMore
+
+	dictOptionMax
+)
+
+// ListOption controls how the list literals are rendered. See examples for
+// details on each specific option.
+type ListOption renderOption
+
+const (
+	// ListOptionSingleLine is the default, render as single line.
+	ListOptionSingleLine ListOption = iota
+	// ListOptionSingleLineComma will render list as single line, with comma after last item.
+	ListOptionSingleLineComma
+	// ListOptionSingleLineCommaTwoAndMore will render list as single line, with comma after last item, if there are two or more items.
+	ListOptionSingleLineCommaTwoAndMore
+
+	// ListOptionMultilineMultiple will render single element lists as single line,
+	// and two and more elements as multiline.
+	ListOptionMultilineMultiple
+	// ListOptionMultilineMultipleComma will render single element lists as single line,
+	// and two and more elements as multiline, with comma after last item.
+	ListOptionMultilineMultipleComma
+	// ListOptionMultilineMultipleCommaTwoAndMore will render single element lists as single line,
+	// and two and more elements as multiline, with comma after last item if two or more elements are present.
+	ListOptionMultilineMultipleCommaTwoAndMore
+
+	// ListOptionMultiline will render list as multiline.
+	ListOptionMultiline
+	// ListOptionMultilineComma will render list as multiline, with comma after last item.
+	ListOptionMultilineComma
+	// ListOptionMultilineCommaTwoAndMore will render list as multiline, with comma after last item, if there are two or more items.
+	ListOptionMultilineCommaTwoAndMore
+
+	listOptionMax
+)
+
+// TupleOption controls how the tuple literals are rendered. See examples for
+// details on each specific option.
+type TupleOption renderOption
+
+const (
+	// TupleOptionSingleLine is the default, render as single line.
+	TupleOptionSingleLine TupleOption = iota
+	// TupleOptionSingleLineComma will render tuple as single line, with comma after last item.
+	TupleOptionSingleLineComma
+	// TupleOptionSingleLineCommaTwoAndMore will render tuple as single line, with comma after last item, if there are two or more items.
+	TupleOptionSingleLineCommaTwoAndMore
+
+	// TupleOptionMultilineMultiple will render single element tuples as single line,
+	// and two and more elements as multiline.
+	TupleOptionMultilineMultiple
+	// TupleOptionMultilineMultipleComma will render single element tuples as single line,
+	// and two and more elements as multiline, with comma after last item.
+	TupleOptionMultilineMultipleComma
+	// TupleOptionMultilineMultipleCommaTwoAndMore will render single element tuples as single line,
+	// and two and more elements as multiline, with comma after last item if two or more elements are present.
+	TupleOptionMultilineMultipleCommaTwoAndMore
+
+	// TupleOptionMultiline will render tuple as multiline.
+	TupleOptionMultiline
+	// TupleOptionMultilineComma will render tuple as multiline, with comma after last item.
+	TupleOptionMultilineComma
+	// TupleOptionMultilineCommaTwoAndMore will render tuple as multiline, with comma after last item, if there are two or more items.
+	TupleOptionMultilineCommaTwoAndMore
+
+	tupleOptionMax
+)
+
+// Option represents Starlark code rendering option.
+type Option func(*outputOpts) (*outputOpts, error)
 
 // WithSpaceEqBinary sets the behavior of how the binary pairs foo=bar are rendered.
 // when set to true, render results are
@@ -78,8 +241,53 @@ func WithIndent(indent string) Option {
 	}
 }
 
-// Option represents Starlark code rendering option.
-type Option func(*outputOpts) (*outputOpts, error)
+// WithCallOption sets the option to render function calls.
+func WithCallOption(value CallOption) Option {
+	return func(o *outputOpts) (*outputOpts, error) {
+		if value >= callOptionMax {
+			return nil, fmt.Errorf("invalid option value %v", value)
+		}
+		c := o.copy()
+		c.callOption = value
+		return c, nil
+	}
+}
+
+// WithDictOption sets the option to render dictionary literals.
+func WithDictOption(value DictOption) Option {
+	return func(o *outputOpts) (*outputOpts, error) {
+		if value >= dictOptionMax {
+			return nil, fmt.Errorf("invalid option value %v", value)
+		}
+		c := o.copy()
+		c.dictOption = value
+		return c, nil
+	}
+}
+
+// WithListOption sets the option to render list literals.
+func WithListOption(value ListOption) Option {
+	return func(o *outputOpts) (*outputOpts, error) {
+		if value >= listOptionMax {
+			return nil, fmt.Errorf("invalid option value %v", value)
+		}
+		c := o.copy()
+		c.listOption = value
+		return c, nil
+	}
+}
+
+// WithTupleOption sets the option to render tuple literals.
+func WithTupleOption(value TupleOption) Option {
+	return func(o *outputOpts) (*outputOpts, error) {
+		if value >= tupleOptionMax {
+			return nil, fmt.Errorf("invalid option value %v", value)
+		}
+		c := o.copy()
+		c.tupleOption = value
+		return c, nil
+	}
+}
 
 func getOutputOpts(options ...Option) (*outputOpts, error) {
 	var (

--- a/example_test.go
+++ b/example_test.go
@@ -115,3 +115,399 @@ func ExampleWithIndent() {
 	// Output: if foo < bar:
 	// ____pass
 }
+
+func ExampleWithCallOption() {
+	matrix := map[CallOption]string{
+		CallOptionMultiline:                        "CallOptionMultiline",
+		CallOptionMultilineComma:                   "CallOptionMultilineComma",
+		CallOptionMultilineCommaTwoAndMore:         "CallOptionMultilineCommaTwoAndMore",
+		CallOptionMultilineMultiple:                "CallOptionMultilineMultiple",
+		CallOptionMultilineMultipleComma:           "CallOptionMultilineMultipleComma",
+		CallOptionMultilineMultipleCommaTwoAndMore: "CallOptionMultilineMultipleCommaTwoAndMore",
+		CallOptionSingleLine:                       "CallOptionSingleLine",
+		CallOptionSingleLineComma:                  "CallOptionSingleLineComma",
+		CallOptionSingleLineCommaTwoAndMore:        "CallOptionSingleLineCommaTwoAndMore",
+	}
+	for i := 0; i < len(matrix); i++ {
+		opt, name := CallOption(i), matrix[CallOption(i)]
+		call := &syntax.CallExpr{
+			Fn: &syntax.Ident{Name: "some_func"},
+			Args: []syntax.Expr{
+				&syntax.Ident{Name: "foo"},
+				&syntax.Ident{Name: "bar"},
+			},
+		}
+		fmt.Println(name)
+		for {
+			exp, err := StarlarkExpr(call, WithCallOption(opt))
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println(exp)
+
+			if len(call.Args) == 0 {
+				break
+			}
+			call.Args = call.Args[:len(call.Args)-1]
+		}
+	}
+	// Output: CallOptionSingleLine
+	// some_func(foo, bar)
+	// some_func(foo)
+	// some_func()
+	// CallOptionSingleLineComma
+	// some_func(foo, bar,)
+	// some_func(foo,)
+	// some_func()
+	// CallOptionSingleLineCommaTwoAndMore
+	// some_func(foo, bar,)
+	// some_func(foo)
+	// some_func()
+	// CallOptionMultilineMultiple
+	// some_func(
+	//     foo,
+	//     bar
+	// )
+	// some_func(foo)
+	// some_func()
+	// CallOptionMultilineMultipleComma
+	// some_func(
+	//     foo,
+	//     bar,
+	// )
+	// some_func(foo,)
+	// some_func()
+	// CallOptionMultilineMultipleCommaTwoAndMore
+	// some_func(
+	//     foo,
+	//     bar,
+	// )
+	// some_func(foo)
+	// some_func()
+	// CallOptionMultiline
+	// some_func(
+	//     foo,
+	//     bar
+	// )
+	// some_func(
+	//     foo
+	// )
+	// some_func()
+	// CallOptionMultilineComma
+	// some_func(
+	//     foo,
+	//     bar,
+	// )
+	// some_func(
+	//     foo,
+	// )
+	// some_func()
+	// CallOptionMultilineCommaTwoAndMore
+	// some_func(
+	//     foo,
+	//     bar,
+	// )
+	// some_func(
+	//     foo
+	// )
+	// some_func()
+}
+
+func ExampleWithDictOption() {
+	matrix := map[DictOption]string{
+		DictOptionMultiline:                        "DictOptionMultiline",
+		DictOptionMultilineComma:                   "DictOptionMultilineComma",
+		DictOptionMultilineCommaTwoAndMore:         "DictOptionMultilineCommaTwoAndMore",
+		DictOptionMultilineMultiple:                "DictOptionMultilineMultiple",
+		DictOptionMultilineMultipleComma:           "DictOptionMultilineMultipleComma",
+		DictOptionMultilineMultipleCommaTwoAndMore: "DictOptionMultilineMultipleCommaTwoAndMore",
+		DictOptionSingleLine:                       "DictOptionSingleLine",
+		DictOptionSingleLineComma:                  "DictOptionSingleLineComma",
+		DictOptionSingleLineCommaTwoAndMore:        "DictOptionSingleLineCommaTwoAndMore",
+	}
+	for i := 0; i < len(matrix); i++ {
+		opt, name := DictOption(i), matrix[DictOption(i)]
+		dict := &syntax.DictExpr{
+			List: []syntax.Expr{
+				&syntax.DictEntry{Key: &syntax.Ident{Name: "foo"}, Value: &syntax.Literal{Value: 1}},
+				&syntax.DictEntry{Key: &syntax.Ident{Name: "bar"}, Value: &syntax.Literal{Value: 2}},
+			},
+		}
+		fmt.Println(name)
+		for {
+			exp, err := StarlarkExpr(dict, WithDictOption(opt))
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println(exp)
+
+			if len(dict.List) == 0 {
+				break
+			}
+			dict.List = dict.List[:len(dict.List)-1]
+		}
+	}
+	// Output: DictOptionSingleLine
+	// {foo: 1, bar: 2}
+	// {foo: 1}
+	// {}
+	// DictOptionSingleLineComma
+	// {foo: 1, bar: 2,}
+	// {foo: 1,}
+	// {}
+	// DictOptionSingleLineCommaTwoAndMore
+	// {foo: 1, bar: 2,}
+	// {foo: 1}
+	// {}
+	// DictOptionMultilineMultiple
+	// {
+	//     foo: 1,
+	//     bar: 2
+	// }
+	// {foo: 1}
+	// {}
+	// DictOptionMultilineMultipleComma
+	// {
+	//     foo: 1,
+	//     bar: 2,
+	// }
+	// {foo: 1,}
+	// {}
+	// DictOptionMultilineMultipleCommaTwoAndMore
+	// {
+	//     foo: 1,
+	//     bar: 2,
+	// }
+	// {foo: 1}
+	// {}
+	// DictOptionMultiline
+	// {
+	//     foo: 1,
+	//     bar: 2
+	// }
+	// {
+	//     foo: 1
+	// }
+	// {}
+	// DictOptionMultilineComma
+	// {
+	//     foo: 1,
+	//     bar: 2,
+	// }
+	// {
+	//     foo: 1,
+	// }
+	// {}
+	// DictOptionMultilineCommaTwoAndMore
+	// {
+	//     foo: 1,
+	//     bar: 2,
+	// }
+	// {
+	//     foo: 1
+	// }
+	// {}
+}
+
+func ExampleWithListOption() {
+	matrix := map[ListOption]string{
+		ListOptionMultiline:                        "ListOptionMultiline",
+		ListOptionMultilineComma:                   "ListOptionMultilineComma",
+		ListOptionMultilineCommaTwoAndMore:         "ListOptionMultilineCommaTwoAndMore",
+		ListOptionMultilineMultiple:                "ListOptionMultilineMultiple",
+		ListOptionMultilineMultipleComma:           "ListOptionMultilineMultipleComma",
+		ListOptionMultilineMultipleCommaTwoAndMore: "ListOptionMultilineMultipleCommaTwoAndMore",
+		ListOptionSingleLine:                       "ListOptionSingleLine",
+		ListOptionSingleLineComma:                  "ListOptionSingleLineComma",
+		ListOptionSingleLineCommaTwoAndMore:        "ListOptionSingleLineCommaTwoAndMore",
+	}
+	for i := 0; i < len(matrix); i++ {
+		opt, name := ListOption(i), matrix[ListOption(i)]
+		list := &syntax.ListExpr{
+			List: []syntax.Expr{
+				&syntax.Ident{Name: "foo"},
+				&syntax.Ident{Name: "bar"},
+			},
+		}
+		fmt.Println(name)
+		for {
+			exp, err := StarlarkExpr(list, WithListOption(opt))
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println(exp)
+
+			if len(list.List) == 0 {
+				break
+			}
+			list.List = list.List[:len(list.List)-1]
+		}
+	}
+	// Output: ListOptionSingleLine
+	// [foo, bar]
+	// [foo]
+	// []
+	// ListOptionSingleLineComma
+	// [foo, bar,]
+	// [foo,]
+	// []
+	// ListOptionSingleLineCommaTwoAndMore
+	// [foo, bar,]
+	// [foo]
+	// []
+	// ListOptionMultilineMultiple
+	// [
+	//     foo,
+	//     bar
+	// ]
+	// [foo]
+	// []
+	// ListOptionMultilineMultipleComma
+	// [
+	//     foo,
+	//     bar,
+	// ]
+	// [foo,]
+	// []
+	// ListOptionMultilineMultipleCommaTwoAndMore
+	// [
+	//     foo,
+	//     bar,
+	// ]
+	// [foo]
+	// []
+	// ListOptionMultiline
+	// [
+	//     foo,
+	//     bar
+	// ]
+	// [
+	//     foo
+	// ]
+	// []
+	// ListOptionMultilineComma
+	// [
+	//     foo,
+	//     bar,
+	// ]
+	// [
+	//     foo,
+	// ]
+	// []
+	// ListOptionMultilineCommaTwoAndMore
+	// [
+	//     foo,
+	//     bar,
+	// ]
+	// [
+	//     foo
+	// ]
+	// []
+}
+
+func ExampleWithTupleOption() {
+	matrix := map[TupleOption]string{
+		TupleOptionMultiline:                        "TupleOptionMultiline",
+		TupleOptionMultilineComma:                   "TupleOptionMultilineComma",
+		TupleOptionMultilineCommaTwoAndMore:         "TupleOptionMultilineCommaTwoAndMore",
+		TupleOptionMultilineMultiple:                "TupleOptionMultilineMultiple",
+		TupleOptionMultilineMultipleComma:           "TupleOptionMultilineMultipleComma",
+		TupleOptionMultilineMultipleCommaTwoAndMore: "TupleOptionMultilineMultipleCommaTwoAndMore",
+		TupleOptionSingleLine:                       "TupleOptionSingleLine",
+		TupleOptionSingleLineComma:                  "TupleOptionSingleLineComma",
+		TupleOptionSingleLineCommaTwoAndMore:        "TupleOptionSingleLineCommaTwoAndMore",
+	}
+	for i := 0; i < len(matrix); i++ {
+		opt, name := TupleOption(i), matrix[TupleOption(i)]
+
+		tuple := &syntax.TupleExpr{
+			List: []syntax.Expr{
+				&syntax.Ident{Name: "foo"},
+				&syntax.Ident{Name: "bar"},
+			},
+		}
+		paren := &syntax.ParenExpr{X: tuple}
+
+		fmt.Println(name)
+		for {
+			exp, err := StarlarkExpr(paren, WithTupleOption(opt))
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println(exp)
+
+			if len(tuple.List) == 0 {
+				break
+			}
+			tuple.List = tuple.List[:len(tuple.List)-1]
+		}
+	}
+	// Output: TupleOptionSingleLine
+	// (foo, bar)
+	// (foo)
+	// ()
+	// TupleOptionSingleLineComma
+	// (foo, bar,)
+	// (foo,)
+	// ()
+	// TupleOptionSingleLineCommaTwoAndMore
+	// (foo, bar,)
+	// (foo)
+	// ()
+	// TupleOptionMultilineMultiple
+	// (
+	//     foo,
+	//     bar
+	// )
+	// (foo)
+	// ()
+	// TupleOptionMultilineMultipleComma
+	// (
+	//     foo,
+	//     bar,
+	// )
+	// (foo,)
+	// ()
+	// TupleOptionMultilineMultipleCommaTwoAndMore
+	// (
+	//     foo,
+	//     bar,
+	// )
+	// (foo)
+	// ()
+	// TupleOptionMultiline
+	// (
+	//     foo,
+	//     bar
+	// )
+	// (
+	//     foo
+	// )
+	// ()
+	// TupleOptionMultilineComma
+	// (
+	//     foo,
+	//     bar,
+	// )
+	// (
+	//     foo,
+	// )
+	// ()
+	// TupleOptionMultilineCommaTwoAndMore
+	// (
+	//     foo,
+	//     bar,
+	// )
+	// (
+	//     foo
+	// )
+	// ()
+}

--- a/render_test.go
+++ b/render_test.go
@@ -64,7 +64,7 @@ func Test_stmtsItem(t *testing.T) {
 			stmts: []syntax.Stmt{&syntax.BranchStmt{Token: syntax.PASS}},
 			want: item{
 				itemType:  stmtsType,
-				addIndent: false,
+				addIndent: 0,
 				stmts:     []syntax.Stmt{&syntax.BranchStmt{Token: syntax.PASS}},
 				valueDesc: "no indent",
 			},
@@ -75,7 +75,7 @@ func Test_stmtsItem(t *testing.T) {
 			addIndent: true,
 			want: item{
 				itemType:  stmtsType,
-				addIndent: true,
+				addIndent: 1,
 				stmts:     []syntax.Stmt{&syntax.BranchStmt{Token: syntax.PASS}},
 				valueDesc: "with indent",
 			},

--- a/testdata/test_input_2.star
+++ b/testdata/test_input_2.star
@@ -1,0 +1,36 @@
+"""example to render multiline items"""
+
+def foo(a, b, c = 4):
+    source = {
+        "z": 12,
+        "c": 14,
+        "d": {
+            "foo": 12,
+            "bar": {
+                "foobar": "test",
+                "sub_bar": 2,
+            },
+        },
+        "lastone": {"foo": "bar",},
+    }
+    t1 = (1,)
+    t2 = (1, 2, 3,)
+    call_something(
+        3,
+        15,
+        foobar,
+        [
+            a,
+            12,
+            (3, 4, 2,),
+            {},
+        ],
+        {
+            "a": "b",
+            "bar": {
+                "foobar": "test",
+                "sub_bar": 2,
+            },
+        },
+    )
+    pass

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -9,8 +9,15 @@ import (
 )
 
 var testSources = map[string][]Option{
-	"testdata/test_input_1.star": {WithSpaceEqBinary(true)},
 	"testdata/import.star":       nil,
+	"testdata/test_input_1.star": {WithSpaceEqBinary(true)},
+	"testdata/test_input_2.star": {
+		WithSpaceEqBinary(true),
+		WithCallOption(CallOptionMultilineMultipleCommaTwoAndMore),
+		WithDictOption(DictOptionMultilineMultipleComma),
+		WithListOption(ListOptionMultilineMultipleComma),
+		WithTupleOption(TupleOptionSingleLineComma),
+	},
 }
 
 func Test_testdata(t *testing.T) {
@@ -37,7 +44,6 @@ func Test_testdata(t *testing.T) {
 				sb.WriteString(d)
 				sep = "\n"
 			}
-
 			if got := sb.String(); want != got {
 				t.Errorf("output mismatch, want %q, got %q", want, got)
 			}


### PR DESCRIPTION
Add new options to render following types as multiline:

 - function calls
 - dictionaries
 - tuples
 - lists