### PR TITLE
Use pointers for render items

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -10,10 +10,10 @@ import (
 	"go.starlark.net/syntax"
 )
 
-func exprSequence(source []syntax.Expr, ro renderOption) []item {
+func exprSequence(source []syntax.Expr, ro renderOption) []*item {
 	var (
-		items        []item
-		sep          []item
+		items        []*item
+		sep          []*item
 		prefixIndent bool
 		lastComma    bool
 		sourceLen    = len(source)
@@ -47,7 +47,7 @@ func exprSequence(source []syntax.Expr, ro renderOption) []item {
 			items = append(items,
 				exprItemIndent(arg, fmt.Sprintf("element %d", i)),
 			)
-			sep = []item{tokenItem(syntax.COMMA, "COMMA"), newlineItem, extraIndentItem}
+			sep = []*item{tokenItem(syntax.COMMA, "COMMA"), newlineItem, extraIndentItem}
 		} else {
 			items = append(items,
 				exprItem(arg, fmt.Sprintf("element %d", i)),
@@ -78,7 +78,7 @@ func binaryExpr(out io.StringWriter, input *syntax.BinaryExpr, opts *outputOpts)
 		return errors.New("rendering binary expression: nil input")
 	}
 
-	items := []item{
+	items := []*item{
 		exprItem(input.X, "X"),
 	}
 
@@ -106,7 +106,7 @@ func callExpr(out io.StringWriter, input *syntax.CallExpr, opts *outputOpts) err
 		return errors.New("rendering call expression: nil input")
 	}
 
-	items := []item{
+	items := []*item{
 		exprItem(input.Fn, "Fn"),
 		tokenItem(syntax.LPAREN, "LPAREN"),
 	}
@@ -131,7 +131,7 @@ func comprehension(out io.StringWriter, input *syntax.Comprehension, opts *outpu
 		tokens = []syntax.Token{syntax.LBRACE, syntax.RBRACE}
 	}
 
-	items := []item{
+	items := []*item{
 		tokenItem(tokens[0], "left token"),
 		exprItem(input.Body, "Body"),
 	}
@@ -210,7 +210,7 @@ func dictExpr(out io.StringWriter, input *syntax.DictExpr, opts *outputOpts) err
 		}
 	}
 
-	items := []item{
+	items := []*item{
 		tokenItem(syntax.LBRACE, "LBRACE"),
 	}
 
@@ -259,7 +259,7 @@ func listExpr(out io.StringWriter, input *syntax.ListExpr, opts *outputOpts) err
 		return errors.New("rendering list expression: nil input")
 	}
 
-	items := []item{
+	items := []*item{
 		tokenItem(syntax.LBRACK, "LBRACK"),
 	}
 
@@ -316,7 +316,7 @@ func sliceExpr(out io.StringWriter, input *syntax.SliceExpr, opts *outputOpts) e
 		return errors.New("rendering slice expression: nil input")
 	}
 
-	items := []item{
+	items := []*item{
 		exprItem(input.X, "X"),
 		tokenItem(syntax.LBRACK, "LBRACK"),
 	}

--- a/render.go
+++ b/render.go
@@ -30,42 +30,46 @@ type item struct {
 }
 
 var (
-	quoteItem       = item{itemType: stringType, value: "\"", valueDesc: "quote"}
-	spaceItem       = item{itemType: stringType, value: " ", valueDesc: "space"}
-	colonItem       = item{itemType: tokenType, token: syntax.COLON, valueDesc: "COLON"}
-	indentItem      = item{itemType: indentType}
-	extraIndentItem = item{itemType: extraIndentType}
-	newlineItem     = item{itemType: tokenType, token: syntax.NEWLINE, valueDesc: "NEWLINE"}
+	quoteItem       = &item{itemType: stringType, value: "\"", valueDesc: "quote"}
+	spaceItem       = &item{itemType: stringType, value: " ", valueDesc: "space"}
+	colonItem       = &item{itemType: tokenType, token: syntax.COLON, valueDesc: "COLON"}
+	indentItem      = &item{itemType: indentType}
+	extraIndentItem = &item{itemType: extraIndentType}
+	newlineItem     = &item{itemType: tokenType, token: syntax.NEWLINE, valueDesc: "NEWLINE"}
 
-	commaSpace = []item{tokenItem(syntax.COMMA, "COMMA"), spaceItem}
+	commaSpace = []*item{tokenItem(syntax.COMMA, "COMMA"), spaceItem}
 )
 
-func exprItem(expr syntax.Expr, desc string) item {
-	return item{itemType: exprType, expr: expr, valueDesc: desc}
+func exprItem(expr syntax.Expr, desc string) *item {
+	return &item{itemType: exprType, expr: expr, valueDesc: desc}
 }
 
-func exprItemIndent(expr syntax.Expr, desc string) item {
-	return item{itemType: exprType, expr: expr, valueDesc: desc, addIndent: 1}
+func exprItemIndent(expr syntax.Expr, desc string) *item {
+	return &item{itemType: exprType, expr: expr, valueDesc: desc, addIndent: 1}
 }
 
-func stmtsItem(stmts []syntax.Stmt, desc string, addIndent bool) item {
+func stmtsItem(stmts []syntax.Stmt, desc string, addIndent bool) *item {
 	aIndent := 0
 	if addIndent {
 		aIndent = 1
 	}
-	return item{itemType: stmtsType, stmts: stmts, valueDesc: desc, addIndent: aIndent}
+	return &item{itemType: stmtsType, stmts: stmts, valueDesc: desc, addIndent: aIndent}
 }
 
-func stringItem(value, desc string) item {
-	return item{itemType: stringType, value: value, valueDesc: desc}
+func stringItem(value, desc string) *item {
+	return &item{itemType: stringType, value: value, valueDesc: desc}
 }
 
-func tokenItem(value syntax.Token, desc string) item {
-	return item{itemType: tokenType, token: value, valueDesc: desc}
+func tokenItem(value syntax.Token, desc string) *item {
+	return &item{itemType: tokenType, token: value, valueDesc: desc}
 }
 
-func render(out io.StringWriter, errPrefix string, opts *outputOpts, items ...item) error {
+func render(out io.StringWriter, errPrefix string, opts *outputOpts, items ...*item) error {
 	for _, i := range items {
+		// panic protection, should not normally happen
+		if i == nil {
+			return fmt.Errorf("nil item in render, errPrefix: %s", errPrefix)
+		}
 		switch i.itemType {
 		case exprType:
 			expOpts := opts

--- a/stmt.go
+++ b/stmt.go
@@ -58,14 +58,14 @@ func defStmt(out io.StringWriter, input *syntax.DefStmt, opts *outputOpts) error
 		return errors.New("rendering def statement: nil input")
 	}
 
-	items := []item{
+	items := []*item{
 		indentItem,
 		tokenItem(syntax.DEF, "DEF"),
 		spaceItem,
 		exprItem(input.Name, "Name"),
 		tokenItem(syntax.LPAREN, "LPAREN"),
 	}
-	var sep []item
+	var sep []*item
 	for i, param := range input.Params {
 		items = append(items,
 			sep...)
@@ -106,7 +106,7 @@ func exprStmt(out io.StringWriter, input *syntax.ExprStmt, opts *outputOpts) err
 			}
 
 			lines := strings.Split(strings.ReplaceAll(strValue, `"""`, `\"\"\"`), "\n")
-			items := []item{
+			items := []*item{
 				indentItem,
 				quoteItem,
 				quoteItem,
@@ -175,7 +175,7 @@ func ifStmt(out io.StringWriter, input *syntax.IfStmt, opts *outputOpts) error {
 		return errors.New("rendering if statement: nil input")
 	}
 
-	items := []item{
+	items := []*item{
 		indentItem,
 		tokenItem(syntax.IF, "IF"),
 		spaceItem,
@@ -205,7 +205,7 @@ func loadStmt(out io.StringWriter, input *syntax.LoadStmt, opts *outputOpts) err
 	if len(input.From) != len(input.To) {
 		return fmt.Errorf("rendering load statement, lengths mismatch, From: %d, To: %d", len(input.From), len(input.To))
 	}
-	items := []item{
+	items := []*item{
 		indentItem,
 		tokenItem(syntax.LOAD, "LOAD"),
 		tokenItem(syntax.LPAREN, "LPAREN"),
@@ -251,7 +251,7 @@ func returnStmt(out io.StringWriter, input *syntax.ReturnStmt, opts *outputOpts)
 		return errors.New("rendering return statement: nil input")
 	}
 
-	items := []item{
+	items := []*item{
 		indentItem,
 		tokenItem(syntax.RETURN, "RETURN"),
 	}


### PR DESCRIPTION
Since the structs are immutable once created, and most of them are
passed as-is, use pointers to reduce memory consumption.