### PR TITLE
Add test for write errors

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -132,7 +132,7 @@ func comprehension(out io.StringWriter, input *syntax.Comprehension, opts *outpu
 	}
 
 	items := []*item{
-		tokenItem(tokens[0], "left token"),
+		tokenItem(tokens[0], "left"),
 		exprItem(input.Body, "Body"),
 	}
 
@@ -162,7 +162,7 @@ func comprehension(out io.StringWriter, input *syntax.Comprehension, opts *outpu
 	}
 
 	items = append(items,
-		tokenItem(tokens[1], "right token"),
+		tokenItem(tokens[1], "right"),
 	)
 
 	return render(out, "rendering comprehension", opts, items...)

--- a/stmt.go
+++ b/stmt.go
@@ -274,7 +274,7 @@ func whileStmt(out io.StringWriter, input *syntax.WhileStmt, opts *outputOpts) e
 		return errors.New("rendering while statement: nil input")
 	}
 
-	return render(out, "rendering if statement", opts,
+	return render(out, "rendering while statement", opts,
 		indentItem,
 		tokenItem(syntax.WHILE, "WHILE"),
 		spaceItem,

--- a/testdata/test_input_1.star
+++ b/testdata/test_input_1.star
@@ -13,6 +13,8 @@ string_value, string_value_2 = "A", "C"
 
 people = {"Alice": 22, "Bob": 40, "Charlie": 55, "Dave": 14}
 
+even_squares = {n: n * n for n in range(10) if n % 2 == 0}
+
 names = ", ".join(people.keys())
 
 mytuple = (1, 2, 3)


### PR DESCRIPTION
In case the writer returns an error, ensure the correct breadcrumbs are
returned to provide the context where the error occured.